### PR TITLE
Fix iPad sharing

### DIFF
--- a/lib/screens/article_screen.dart
+++ b/lib/screens/article_screen.dart
@@ -53,18 +53,31 @@ class _ArticleScreenState extends State<ArticleScreen> {
     checkIfLiked();
   }
 
+  void _onShare(BuildContext context) async {
+    final box = context.findRenderObject() as RenderBox?;
+    try {
+      await Share.share(
+        '${widget.title}\n\n${widget.url}\n\n\nDOI: ${widget.doi}\n${AppLocalizations.of(context)!.sharedMessage} 👻',
+        sharePositionOrigin: box!.localToGlobal(Offset.zero) & box.size,
+      );
+    } catch (e) {
+      debugPrint('Shared too fast: {$e}');
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
         title: Text(widget.title),
         actions: [
-          IconButton(
-              onPressed: () {
-                Share.share(
-                    '${widget.title}\n\n${widget.url}\n\n\nDOI: ${widget.doi}\n${AppLocalizations.of(context)!.sharedMessage} 👻');
-              },
-              icon: Icon(Icons.share_outlined))
+          Builder(
+            builder: (BuildContext context) {
+              return IconButton(
+                  onPressed: () => _onShare(context),
+                  icon: Icon(Icons.share_outlined));
+            },
+          ),
         ],
       ),
       body: SingleChildScrollView(

--- a/lib/widgets/publication_card.dart
+++ b/lib/widgets/publication_card.dart
@@ -179,8 +179,18 @@ class _PublicationCardState extends State<PublicationCard> {
                                   duration: const Duration(seconds: 1),
                                 ));
                               } else if (result == SampleItem.itemThree) {
-                                Share.share(
-                                    '${widget.title}\n\n${widget.url}\n\n\nDOI: ${widget.doi}\n${AppLocalizations.of(context)!.sharedMessage} 👻');
+                                final box =
+                                    context.findRenderObject() as RenderBox?;
+                                try {
+                                  Share.share(
+                                    '${widget.title}\n\n${widget.url}\n\n\nDOI: ${widget.doi}\n${AppLocalizations.of(context)!.sharedMessage} 👻',
+                                    sharePositionOrigin:
+                                        box!.localToGlobal(Offset.zero) &
+                                            box.size,
+                                  );
+                                } catch (e) {
+                                  debugPrint('Shared too fast: {$e}');
+                                }
                               }
                             });
                           },


### PR DESCRIPTION
The share button was crashing the app on iPad. Had to provide sharePositionOrigin parameter as stated in the share_plus documentation.