### PR TITLE
Fix abstracts unavailable when setting is on hide all

### DIFF
--- a/lib/services/database_helper.dart
+++ b/lib/services/database_helper.dart
@@ -457,6 +457,18 @@ class DatabaseHelper {
     });
   }
 
+  Future<String?> getAbstract(String doi) async {
+    final db = await database;
+    final result = await db.query(
+      'articles',
+      columns: ['abstract'],
+      where: 'doi = ?',
+      whereArgs: [doi],
+    );
+
+    return result.isNotEmpty ? result.first['abstract'] as String? : null;
+  }
+
   Future<void> removeDownloaded(String doi) async {
     final db = await database;
 

--- a/lib/widgets/publication_card.dart
+++ b/lib/widgets/publication_card.dart
@@ -75,7 +75,15 @@ class _PublicationCardState extends State<PublicationCard> {
     }
 
     return GestureDetector(
-      onTap: () {
+      onTap: () async {
+        String finalAbstract = widget.abstract;
+
+        if (widget.abstract.isEmpty) {
+          final dbAbstract = await databaseHelper.getAbstract(widget.doi);
+          if (dbAbstract != null && dbAbstract.isNotEmpty) {
+            finalAbstract = dbAbstract;
+          }
+        }
         // Navigate to the ArticleScreen when the card is tapped
         Navigator.push(
           context,
@@ -84,7 +92,7 @@ class _PublicationCardState extends State<PublicationCard> {
               doi: widget.doi,
               title: widget.title,
               issn: widget.issn,
-              abstract: widget.abstract,
+              abstract: finalAbstract,
               journalTitle: widget.journalTitle,
               publishedDate: widget.publishedDate,
               authors: widget.authors,


### PR DESCRIPTION
When the publication card display setting is set on "hide all", it would prevent abstracts from being shown in the article screen.