### PR TITLE
Temptative fix for journals with multiple ISSNs

### DIFF
--- a/lib/models/crossref_journals_models.dart
+++ b/lib/models/crossref_journals_models.dart
@@ -96,7 +96,7 @@ class Item {
     required this.issnType,
   });
 
-  factory Item.fromJson(Map<String, dynamic> json) => Item(
+  factory Item.fromJson(Map<String, dynamic> json, [String? queriedISSN]) => Item(
         lastStatusCheckTime: json["last-status-check-time"] ?? 0,
         counts: Counts.fromJson(json["counts"] ?? {}),
         breakdowns: Breakdowns.fromJson(json["breakdowns"] ?? {}),
@@ -107,7 +107,7 @@ class Item {
         coverageType: CoverageType.fromJson(json["coverage-type"] ?? {}),
         flags: Map.from(json["flags"] ?? {})
             .map((k, v) => MapEntry<String, bool>(k, v ?? false)),
-        issn: List<String>.from(json["ISSN"]?.map((x) => x) ?? []),
+        issn: queriedISSN != null ? <String>[queriedISSN] : List<String>.from(json["ISSN"]?.map((x) => x) ?? []),
         issnType: List<IssnType>.from(
           (json["issn-type"] ?? []).map((x) => IssnType.fromJson(x)),
         ),

--- a/lib/models/crossref_journals_models.dart
+++ b/lib/models/crossref_journals_models.dart
@@ -96,7 +96,8 @@ class Item {
     required this.issnType,
   });
 
-  factory Item.fromJson(Map<String, dynamic> json, [String? queriedISSN]) => Item(
+  factory Item.fromJson(Map<String, dynamic> json, [String? queriedISSN]) =>
+      Item(
         lastStatusCheckTime: json["last-status-check-time"] ?? 0,
         counts: Counts.fromJson(json["counts"] ?? {}),
         breakdowns: Breakdowns.fromJson(json["breakdowns"] ?? {}),
@@ -107,7 +108,9 @@ class Item {
         coverageType: CoverageType.fromJson(json["coverage-type"] ?? {}),
         flags: Map.from(json["flags"] ?? {})
             .map((k, v) => MapEntry<String, bool>(k, v ?? false)),
-        issn: queriedISSN != null ? <String>[queriedISSN] : List<String>.from(json["ISSN"]?.map((x) => x) ?? []),
+        issn: (queriedISSN != null && json["ISSN"].contains(queriedISSN))
+            ? <String>[queriedISSN]
+            : List<String>.from(json["ISSN"]?.map((x) => x) ?? []),
         issnType: List<IssnType>.from(
           (json["issn-type"] ?? []).map((x) => IssnType.fromJson(x)),
         ),

--- a/lib/services/crossref_api.dart
+++ b/lib/services/crossref_api.dart
@@ -58,7 +58,7 @@ class CrossRefApi {
       var message = jsonResponse['message'];
 
       if (message != null) {
-        Journals.Item item = Journals.Item.fromJson(message);
+        Journals.Item item = Journals.Item.fromJson(message, query);
 
         return ListAndMore(
           list: [item],


### PR DESCRIPTION
Hello,

I had a problem with journals with multiple ISSNs where the selected ISSN by default was no longer in use. See for example Physical Review B where the default ISSN 1098-0121 was in use until 2015. The ISSN currently in use comes only later in the list. With this PR, when searching journals by ISSN the selected ISSN is the one that is searched for.

Another way to resolve this would have been to show all the ISSN for a journal and let the user choose. But this would require a bit more work and refactoring.