### PR TITLE
Add edit button in library screen

### DIFF
--- a/lib/widgets/journal_card.dart
+++ b/lib/widgets/journal_card.dart
@@ -7,8 +7,13 @@ import '../models/journal_entity.dart';
 class JournalCard extends StatelessWidget {
   final Journal journal;
   final Function(BuildContext, Journal) unfollowCallback;
+  final bool showDeleteButton;
 
-  const JournalCard({required this.journal, required this.unfollowCallback});
+  const JournalCard({
+    required this.journal,
+    required this.unfollowCallback,
+    this.showDeleteButton = false,
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -61,13 +66,13 @@ class JournalCard extends StatelessWidget {
                 overflow: TextOverflow.ellipsis,
               ),
             ),
-            TextButton(
-              onPressed: () {
-                // Perform the unfollow action
-                unfollowCallback(context, journal);
-              },
-              child: Text(AppLocalizations.of(context)!.unfollow),
-            ),
+            if (showDeleteButton)
+              TextButton(
+                onPressed: () {
+                  unfollowCallback(context, journal);
+                },
+                child: Text(AppLocalizations.of(context)!.unfollow),
+              ),
           ],
         ),
         subtitle: Column(

--- a/lib/widgets/journals_tab_content.dart
+++ b/lib/widgets/journals_tab_content.dart
@@ -25,6 +25,7 @@ class JournalsTabContent extends StatefulWidget {
 
 class _JournalsTabContentState extends State<JournalsTabContent> {
   late DatabaseHelper dbHelper;
+  bool _isEditing = false;
 
   @override
   void initState() {
@@ -50,13 +51,15 @@ class _JournalsTabContentState extends State<JournalsTabContent> {
                     TextButton.styleFrom(visualDensity: VisualDensity.compact),
               ),
               TextButton.icon(
-                onPressed: () => _showSortDialog(context),
-                icon: Icon(
-                  widget.initialSortOrder == 0
-                      ? Icons.arrow_downward
-                      : Icons.arrow_upward,
-                ),
-                label: Text("Edit"),
+                onPressed: () {
+                  setState(() {
+                    _isEditing = !_isEditing;
+                  });
+                },
+                icon: Icon(_isEditing ? Icons.check : Icons.edit),
+                label: Text(_isEditing
+                    ? AppLocalizations.of(context)!.done
+                    : AppLocalizations.of(context)!.edit),
                 style:
                     TextButton.styleFrom(visualDensity: VisualDensity.compact),
               ),
@@ -115,6 +118,7 @@ class _JournalsTabContentState extends State<JournalsTabContent> {
                         JournalCard(
                           journal: currentJournal,
                           unfollowCallback: _unfollowJournal,
+                          showDeleteButton: _isEditing,
                         ),
                       ],
                     );

--- a/lib/widgets/queries_tab_content.dart
+++ b/lib/widgets/queries_tab_content.dart
@@ -25,6 +25,7 @@ class QueriesTabContent extends StatefulWidget {
 class _QueriesTabContentState extends State<QueriesTabContent> {
   final dbHelper = DatabaseHelper();
   late Future<List<Map<String, dynamic>>> savedQueriesFuture;
+  bool _isEditing = false;
 
   @override
   void initState() {
@@ -50,13 +51,15 @@ class _QueriesTabContentState extends State<QueriesTabContent> {
                     TextButton.styleFrom(visualDensity: VisualDensity.compact),
               ),
               TextButton.icon(
-                onPressed: () => _showSortDialog(context),
-                icon: Icon(
-                  widget.initialSortOrder == 0
-                      ? Icons.arrow_downward
-                      : Icons.arrow_upward,
-                ),
-                label: Text("Edit"),
+                onPressed: () {
+                  setState(() {
+                    _isEditing = !_isEditing;
+                  });
+                },
+                icon: Icon(_isEditing ? Icons.check : Icons.edit),
+                label: Text(_isEditing
+                    ? AppLocalizations.of(context)!.done
+                    : AppLocalizations.of(context)!.edit),
                 style:
                     TextButton.styleFrom(visualDensity: VisualDensity.compact),
               ),
@@ -113,6 +116,7 @@ class _QueriesTabContentState extends State<QueriesTabContent> {
                       queryParams: query['queryParams'],
                       queryProvider: query['queryProvider'],
                       dateSaved: query['dateSaved'],
+                      showDeleteButton: _isEditing,
                       onDelete: () async {
                         await dbHelper.deleteQuery(query['query_id']);
                         setState(() {

--- a/lib/widgets/search_query_card.dart
+++ b/lib/widgets/search_query_card.dart
@@ -13,6 +13,7 @@ class SearchQueryCard extends StatefulWidget {
   final String queryParams;
   final String queryProvider;
   final String dateSaved;
+  final bool showDeleteButton;
   final VoidCallback? onDelete;
 
   const SearchQueryCard({
@@ -21,6 +22,7 @@ class SearchQueryCard extends StatefulWidget {
     required this.queryName,
     required this.queryParams,
     required this.queryProvider,
+    this.showDeleteButton = false,
     required this.dateSaved,
     this.onDelete,
   }) : super(key: key);
@@ -198,7 +200,7 @@ class _SearchQueryCardState extends State<SearchQueryCard> {
                       fontWeight: FontWeight.bold,
                     ),
                   ),
-                  if (widget.onDelete != null)
+                  if (widget.showDeleteButton && widget.onDelete != null)
                     IconButton(
                       icon: const Icon(Icons.delete_outline),
                       onPressed: widget.onDelete,


### PR DESCRIPTION
Hide the unfollow/delete buttons on the journal/saved query cards in the library screen, unless in edit mode