### PR TITLE
Add paper count in feed

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -47,6 +47,14 @@
   "@notificationTitleJournal": {},
   "notificationTitleQuery": "Queries were updated",
   "@notificationTitleQuery": {},
+  "numberPublications": "{count, plural, =0{No publications} =1{1 publication} other{{count} publications}}",
+  "@numberPublications": {
+    "placeholders": {
+      "count": {}
+    }
+  },
+  "showPublicationCount": "Show publication count",
+  "@showPublicationCount":{},
   "selectFeed": "Select a feed",
   "@selectFeed": {},
   "createCustomFeed": "Create a custom feed",


### PR DESCRIPTION
- Adds a publication count in the feed, above publication cards as suggested in #249 
- Adds a setting in Display settings to toggle the publication count, default is disabled
- The publication count displays the number of items in the ListView, so it displays the correct number for custom feeds and search filters too
