### PR TITLE
Fix old devices overriding cloud data

### DIFF
--- a/lib/screens/article_screen.dart
+++ b/lib/screens/article_screen.dart
@@ -837,21 +837,21 @@ class ArticleScreenState extends State<ArticleScreen> {
 
                               if (isLiked) {
                                 await databaseHelper.insertArticle(
-                                  PublicationCard(
-                                    title: widget.title,
-                                    abstract: widget.abstract,
-                                    journalTitle: widget.journalTitle,
-                                    issn: widget.issn,
-                                    publishedDate: widget.publishedDate,
-                                    doi: widget.doi,
-                                    authors: widget.authors,
-                                    url: widget.url,
-                                    license: widget.license,
-                                    licenseName: widget.licenseName,
-                                    publisher: widget.publisher,
-                                  ),
-                                  isLiked: true,
-                                );
+                                    PublicationCard(
+                                      title: widget.title,
+                                      abstract: widget.abstract,
+                                      journalTitle: widget.journalTitle,
+                                      issn: widget.issn,
+                                      publishedDate: widget.publishedDate,
+                                      doi: widget.doi,
+                                      authors: widget.authors,
+                                      url: widget.url,
+                                      license: widget.license,
+                                      licenseName: widget.licenseName,
+                                      publisher: widget.publisher,
+                                    ),
+                                    isLiked: true,
+                                    updateSyncTimestamp: true);
                               } else {
                                 await databaseHelper.removeFavorite(widget.doi);
                               }

--- a/lib/services/database_helper.dart
+++ b/lib/services/database_helper.dart
@@ -713,6 +713,7 @@ class DatabaseHelper {
     bool isSavedQuery = false,
     int? queryId,
     String pdfPath = '',
+    bool updateSyncTimestamp = false,
   }) async {
     final db = await database;
 
@@ -727,7 +728,9 @@ class DatabaseHelper {
     if (existingArticle.isNotEmpty) {
       // Article already exists, update the timestamp based on parameters
       final Map<String, dynamic> updateData = {};
-      updateData['updated_at'] = DateTime.now().toUtc().toIso8601String();
+      if (updateSyncTimestamp) {
+        updateData['updated_at'] = DateTime.now().toUtc().toIso8601String();
+      }
 
       if (isLiked && existingArticle[0]['dateLiked'] == null) {
         updateData['dateLiked'] =
@@ -779,7 +782,9 @@ class DatabaseHelper {
         'dateCached': isCached ? DateTime.now().toIso8601String() : null,
         'isSavedQuery': isSavedQuery ? 1 : 0,
         'query_id': queryId,
-        'updated_at': DateTime.now().toUtc().toIso8601String(),
+        'updated_at': updateSyncTimestamp
+            ? DateTime.now().toUtc().toIso8601String()
+            : DateTime.fromMillisecondsSinceEpoch(0).toUtc().toIso8601String(),
         'sync_id': const Uuid().v7(),
         'journal_id': journalId,
       });

--- a/lib/widgets/publication_card/publication_card.dart
+++ b/lib/widgets/publication_card/publication_card.dart
@@ -149,7 +149,8 @@ class PublicationCardState extends State<PublicationCard>
   void _handleFavoriteToggle() async {
     setState(() => isLiked = !isLiked);
     if (isLiked) {
-      await databaseHelper.insertArticle(widget, isLiked: true);
+      await databaseHelper.insertArticle(widget,
+          isLiked: true, updateSyncTimestamp: true);
     } else {
       await databaseHelper.removeFavorite(widget.doi);
     }
@@ -181,7 +182,8 @@ class PublicationCardState extends State<PublicationCard>
       case SwipeAction.favorite:
         setState(() => isLiked = !isLiked);
         if (isLiked) {
-          await databaseHelper.insertArticle(widget, isLiked: true);
+          await databaseHelper.insertArticle(widget,
+              isLiked: true, updateSyncTimestamp: true);
         } else {
           await databaseHelper.removeFavorite(widget.doi);
         }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -29,10 +29,10 @@ packages:
     dependency: "direct main"
     description:
       name: background_fetch
-      sha256: f5f0a5774cbe5e71ce62a9daf7f01007d07b3ac0c1fea1ecb131a3c5a273ca38
+      sha256: "360697885b0a0d3d3045ee1e1dcce19486319b8cb9df2d0ef07518f737bebb31"
       url: "https://pub.dev"
     source: hosted
-    version: "1.5.1"
+    version: "1.6.2"
   boolean_selector:
     dependency: transitive
     description:
@@ -473,10 +473,10 @@ packages:
     dependency: transitive
     description:
       name: hooks
-      sha256: e79ed1e8e1929bc6ecb6ec85f0cb519c887aa5b423705ded0d0f2d9226def388
+      sha256: "025f060e86d2d4c3c47b56e33caf7f93bf9283340f26d23424ebcfccf34f621e"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.2"
+    version: "1.0.3"
   html:
     dependency: "direct main"
     description:
@@ -901,6 +901,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.2.0"
+  record_use:
+    dependency: transitive
+    description:
+      name: record_use
+      sha256: "2551bd8eecfe95d14ae75f6021ad0248be5c27f138c2ec12fcb52b500b3ba1ed"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.6.0"
   remove_unused_localizations:
     dependency: "direct dev"
     description:
@@ -1054,10 +1062,10 @@ packages:
     dependency: "direct main"
     description:
       name: sqflite
-      sha256: e2297b1da52f127bc7a3da11439985d9b536f75070f3325e62ada69a5c585d03
+      sha256: "564cfed0746fe53140c23b70b308e045c3b31f17778f2f326ccb7d804ea0250a"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.2"
+    version: "2.4.2+1"
   sqflite_android:
     dependency: transitive
     description:
@@ -1070,18 +1078,18 @@ packages:
     dependency: transitive
     description:
       name: sqflite_common
-      sha256: "6ef422a4525ecc601db6c0a2233ff448c731307906e92cabc9ba292afaae16a6"
+      sha256: "5e8377564d95166761a968ed96104e0569b6b6cc611faac92a36ab8a169112c3"
       url: "https://pub.dev"
     source: hosted
-    version: "2.5.6"
+    version: "2.5.6+1"
   sqflite_common_ffi:
     dependency: "direct main"
     description:
       name: sqflite_common_ffi
-      sha256: c59fcdc143839a77581f7a7c4de018e53682408903a0a0800b95ef2dc4033eff
+      sha256: cd0c7f7de39a08f2d54ef144d9058c46eca8461879aaa648025643455c1e5a20
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.0+2"
+    version: "2.4.0+3"
   sqflite_darwin:
     dependency: transitive
     description:
@@ -1134,10 +1142,10 @@ packages:
     dependency: transitive
     description:
       name: synchronized
-      sha256: c254ade258ec8282947a0acbbc90b9575b4f19673533ee46f2f6e9b3aeefd7c0
+      sha256: "63896c27e81b28f8cb4e69ead0d3e8f03f1d1e5fc531a3e579cabed6a2c7c9e5"
       url: "https://pub.dev"
     source: hosted
-    version: "3.4.0"
+    version: "3.4.0+1"
   term_glyph:
     dependency: transitive
     description:
@@ -1286,10 +1294,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: "45caa6c5917fa127b5dbcfbd1fa60b14e583afdc08bfc96dda38886ca252eb60"
+      sha256: "046d3928e16fa4dc46e8350415661755ab759d9fc97fc21b5ab295f71e4f0499"
       url: "https://pub.dev"
     source: hosted
-    version: "15.0.2"
+    version: "15.1.0"
   web:
     dependency: transitive
     description:
@@ -1339,5 +1347,5 @@ packages:
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: ">=3.10.3 <4.0.0"
+  dart: ">=3.11.0 <4.0.0"
   flutter: ">=3.41.7"


### PR DESCRIPTION
Fixes a sync issue where if a device's database didn't contain an article that was already synced from another device, the local database would insert the article before the sync runs. The updated_at timestamp would be set to the time of insertion and when the sync ran, it would override the cloud data.